### PR TITLE
fix: check for cli error and fail accordingly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(async move {
         if let Err(err) = signal::ctrl_c().await {
-            eprintln!("Failed to listen for shutdown signal: {:#}", err);
+            eprintln!("Failed to listen for shutdown signal: {err:#}");
         }
         notify_clone.notify_one();
     });

--- a/src/routes/duplicate.rs
+++ b/src/routes/duplicate.rs
@@ -112,6 +112,8 @@ pub async fn handler(
         pipe.write_all(&chunk).await?;
     }
 
+    pipe.shutdown().await?;
+
     let res = child.wait_with_output().await?;
 
     if !res.status.success() {


### PR DESCRIPTION
Cli seems to be failing silently. This patch adds more rigorous error handling:
<img width="1191" height="681" alt="image" src="https://github.com/user-attachments/assets/223a87d0-5c21-4781-b609-3938c09628d6" />
